### PR TITLE
[FIX] 최신 등록된 가족 그룹 이미지 방어 코드 설정

### DIFF
--- a/src/main/java/com/example/server/converter/UserConverter.java
+++ b/src/main/java/com/example/server/converter/UserConverter.java
@@ -64,6 +64,7 @@ public class UserConverter {
 
         // 최신 등록된 가족 그룹 이미지
         String latestFamilyImage = user.getFamilyMembers().stream()
+                .filter(fm -> fm.getFamily() != null && fm.getFamily().getImage() != null)
                 .sorted(Comparator.comparing(fm -> fm.getFamily().getId(), Comparator.reverseOrder()))
                 .map(fm -> fm.getFamily().getImage())
                 .findFirst()

--- a/src/main/java/com/example/server/service/user/UserService.java
+++ b/src/main/java/com/example/server/service/user/UserService.java
@@ -80,7 +80,8 @@ public class UserService {
                 .orElseThrow(() -> new CustomException(ErrorStatus.USER_NOT_FOUND));
 
         // 유저가 속한 가족 그룹
-        List<Family> families = user.getFamilyMembers().stream()
+        List<FamilyMember> familyMembers = familyMemberRepository.findAllByUser(user);
+        List<Family> families = familyMembers.stream()
                 .map(FamilyMember::getFamily)
                 .distinct()
                 .toList();


### PR DESCRIPTION
### 🙌 작업 내용
- 최신 등록된 가족 그룹 이미지 방어 코드 설정
.getFamily()에서 NPE가 터짐 → 즉 JPA가 그걸 null로 본 상황 해결